### PR TITLE
Singapore - missing products logic condition to pick blank product_key

### DIFF
--- a/models/singapore/sgpwks_integration/pos/sgpwks_integration__notify_missing_products.sql
+++ b/models/singapore/sgpwks_integration/pos/sgpwks_integration__notify_missing_products.sql
@@ -14,6 +14,7 @@ final as (
         item_desc as customer_product_name,
         source,
         count(*) as record_count
-    from source where product_key is null group by 1,2,3,4,5
+    from source 
+    where product_key = '' or product_key is null group by 1,2,3,4,5
 )
 select * from final


### PR DESCRIPTION
Singapore - missing products logic condition to pick blank product_key

## Description & motivation
Singapore - missing products logic condition to pick blank product_key
Model effected : 
sgpwks_integration__notify_missing_products.sql