### PR TITLE
Updated logic for SFMC tables

### DIFF
--- a/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_children_data.sql
+++ b/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_children_data.sql
@@ -1,8 +1,8 @@
 {{
     config(
         materialized="incremental",
-        incremental_strategy= "delete+insert",
-        unique_key=  ['cntry_cd']
+        incremental_strategy="append",
+        pre_hook="delete from {{this}} where cntry_cd='TH' and crtd_dttm < (select min(crtd_dttm) from {{ source('thasdl_raw', 'sdl_th_sfmc_children_data') }})"
     )
 }}
 with 

--- a/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_consumer_master.sql
+++ b/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_consumer_master.sql
@@ -1,9 +1,8 @@
 {{
     config(
         materialized="incremental",
-        incremental_strategy= "delete+insert",
-        unique_key=  ['cntry_cd'],
-        sql_header="USE WAREHOUSE "+ env_var("DBT_ENV_CORE_DB_MEDIUM_WH")+ ";"
+        incremental_strategy="append",
+        pre_hook="delete from {{this}} where cntry_cd='TH' and crtd_dttm < (select min(crtd_dttm) from {{ source('thasdl_raw', 'sdl_th_sfmc_consumer_master') }})"
     )
 }}
 with 

--- a/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_consumer_master_additional.sql
+++ b/models/asp_regional/aspitg_integration/sfmc/master/aspitg_integration__itg_sfmc_consumer_master_additional.sql
@@ -1,9 +1,8 @@
 {{
     config(
         materialized="incremental",
-        incremental_strategy= "delete+insert",
-        unique_key=  ['cntry_cd'],
-        sql_header="USE WAREHOUSE "+ env_var("DBT_ENV_CORE_DB_MEDIUM_WH")+ ";"
+        incremental_strategy="append",
+        pre_hook="delete from {{this}} where cntry_cd='TH' and crtd_dttm < (select min(crtd_dttm) from {{ source('thasdl_raw', 'sdl_th_sfmc_consumer_master_additional') }})"
     )
 }}
 with source as


### PR DESCRIPTION
Fixed timeout issue for the following SFMC tables:
- itg_sfmc_consumer_master
- itg_sfmc_consumer_master_additional
- itg_sfmc_children_data