### PR TITLE
Fixed a model and deactivated few models

### DIFF
--- a/macros/japan_dcl/macro_update_hanyo_attrandtm06dmout.sql
+++ b/macros/japan_dcl/macro_update_hanyo_attrandtm06dmout.sql
@@ -19,12 +19,12 @@
                 ATT.ATTR2,
                 ATT.ATTR4,
                 ATT.INSERTDATE
-        FROM DEV_DNA_CORE.JPDCLEDW_INTEGRATION.CIR07DMPRN DMP
+        FROM {{ ref('jpndcledw_integration__cir07dmprn') }} DMP
         INNER JOIN {{this}} ATT ON ATT.KBNMEI = 'DMCHUKUBUN'
                 AND ATT.ATTR1 = DMP.DMPRNNO
         WHERE DMP.DMPRNNO IN (
                     SELECT DMPRNNO
-                    FROM DEV_DNA_CORE.JPDCLEDW_INTEGRATION.CIR07DMPRN DMP
+                    FROM {{ ref('jpndcledw_integration__cir07dmprn') }} DMP
                     LEFT JOIN {{this}} ATTR ON ATTR.KBNMEI = 'DMCHUKUBUN'
                             AND ATTR.ATTR1 = DMP.DMPRNNO
                     WHERE DMP.INSERTDATE > ATTR.INSERTDATE
@@ -58,12 +58,12 @@
                 ATT.ATTR2,
                 ATT.ATTR4,
                 ATT.INSERTDATE
-        FROM DEV_DNA_CORE.JPDCLEDW_INTEGRATION.CIR07DMPRN DMP
+        FROM {{ ref('jpndcledw_integration__cir07dmprn') }} DMP
         INNER JOIN {{this}} ATT ON ATT.KBNMEI = 'DMSYOKUBUN'
                 AND ATT.ATTR1 = DMP.DMPRNNO
         WHERE DMP.DMPRNNO IN (
                     SELECT DMPRNNO
-                    FROM DEV_DNA_CORE.JPDCLEDW_INTEGRATION.CIR07DMPRN DMP
+                    FROM {{ ref('jpndcledw_integration__cir07dmprn') }} DMP
                     LEFT JOIN {{this}} ATTR ON ATTR.KBNMEI = 'DMSYOKUBUN'
                             AND ATTR.ATTR1 = DMP.DMPRNNO
                     WHERE DMP.INSERTDATE > ATTR.INSERTDATE

--- a/models/japan_dcl/jpndcledw_integration/edw/_jpndcledw_integration__edw.yml
+++ b/models/japan_dcl/jpndcledw_integration/edw/_jpndcledw_integration__edw.yml
@@ -615,7 +615,7 @@ models:
   - name: jpndcledw_integration__wqwt74tbl_new
     config:
       alias: '"wqwt74戦略商品別売上ｐ_tbl_new"'
-      tags: ["m_dcl_edw_job2","transformation"] 
+      tags: ["m_dcl_edw_job2","inactive"] 
   - name: jpndcledw_integration__hanyo_attr
     config:
       alias: hanyo_attr
@@ -816,15 +816,15 @@ models:
   - name: jpndcledw_integration__cit85osalh_hen_mv_tbl
     config:
       alias: cit85osalh_hen_mv_tbl
-      tags: ["m_dcl_edw_job1","transformation"]
+      tags: ["m_dcl_edw_job1","inactive"]
   - name: jpndcledw_integration__cit85osalh_uri_mv_tbl
     config:
       alias: cit85osalh_uri_mv_tbl
-      tags: ["m_dcl_edw_job1","transformation"]
+      tags: ["m_dcl_edw_job1","inactive"]
   - name: jpndcledw_integration__cit86osalm_uri_mv_tbl 
     config:
       alias: cit86osalm_uri_mv_tbl
-      tags: ["m_dcl_edw_job1","transformation"] 
+      tags: ["m_dcl_edw_job1","inactive"] 
   - name: jpndcledw_integration__tbecordermeisai_mv_tbl
     config:
       alias: tbecordermeisai_mv_tbl

--- a/models/japan_dcl/jpndcledw_integration/edw/jpndcledw_integration__hanyo_attr.sql
+++ b/models/japan_dcl/jpndcledw_integration/edw/jpndcledw_integration__hanyo_attr.sql
@@ -1,167 +1,39 @@
 
 {{
-    config(
+    config
+    (
         materialized= "incremental",
         incremental_strategy= "append",
-        post_hook = "{{macro_update_hanyo_attrandtm06dmout()}}"
+        pre_hook = "
+                    {% if is_incremental() %}
+                    DELETE
+                    FROM {{this}} HANYO_ATTR using {{ ref('jpndclitg_integration__hanyo_attr_temp') }} HANYO_WORK_TEMP
+                    WHERE HANYO_ATTR.KBNMEI = HANYO_WORK_TEMP.KBNMEI
+                        AND HANYO_ATTR.ATTR1 = HANYO_WORK_TEMP.ATTR1;
+                    {% endif %}
+                    ",
+        post_hook = "{{ macro_update_hanyo_attrandtm06dmout() }}"
     )
 }}
 
-with cir07dmprn as (
-    select * from  {{ ref('jpndcledw_integration__cir07dmprn') }}
-),
-tm06dmout as (
-    select * from  {{ ref('jpndcledw_integration__tm06dmout') }}
-),
-hanyo_work_temp as (
-select 'DMDAIKUBUN' as kbnmei,
-      dm.dmprnno as attr1,
-      substring(dm.comment1, 1, 40) as attr2,
-      '01' as attr3,
-      '会報誌' as attr4,
-      null as attr5
-from cir07dmprn dm
-where dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-      or dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-),
-cte1 as (
-select *
-from {{this}} hanyo_attr where not exists (
-    select 1
-    from hanyo_work_temp
-    where hanyo_attr.kbnmei = hanyo_work_temp.kbnmei
-          and hanyo_attr.attr1 = hanyo_work_temp.attr1
-)) ,
-insert_1 as  (
-    select * from cte1 
-    union all
-    select kbnmei,
-      attr1,
-      attr2,
-      attr3,
-      attr4,
-      attr5,
-      sysdate(),
-    null as updatedate,
-    null as inserted_date,
-    null as inserted_by,
-    null as updated_date,
-    null as updated_by,
-    null as source_file_date
-from hanyo_work_temp
-),
-tm06_next as (
-      select cast(max(lpad(dmchubuncode, 3, '0')) || 1 as varchar) as dmchubuncode
-      from tm06dmout tm06dmout
-      where dmdaibunname = '会報誌'
-      ) ,
-hanyo_work_temp_2 as (
-select 'DMCHUKUBUN' as kbnmei,
-      dm.dmprnno as attr1,
-      substring(dm.comment1, 1, 40) as attr2,
-      tm06_next.dmchubuncode as attr3,
-      case 
-            when dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-                  then replace(regexp_substr(dm.comment1, 'clﾌﾟﾚﾐｱﾑ.*号'), 'clﾌﾟﾚﾐｱﾑ', '')
-            when dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-                  then replace(regexp_substr(dm.comment1, 'ｼｰﾗﾊﾞｰ.*号'), 'ｼｰﾗﾊﾞｰ', '')
-            end as attr4,
-      null as attr5
-from cir07dmprn dm
-inner join  tm06_next on 1 = 1
-where dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-      or dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-),
-cte2 as (
-    select hanyo_attr.* 
-from insert_1 hanyo_attr where not exists (
-    select 1
-    from hanyo_work_temp_2
-    where hanyo_attr.kbnmei = hanyo_work_temp_2.kbnmei
-          and hanyo_attr.attr1 = hanyo_work_temp_2.attr1
-)
-) ,
-insert_2 as (
-select * from cte2
-union all
-select kbnmei,
-      attr1,
-      attr2,
-      attr3,
-      attr4,
-      attr5,
-      sysdate(),
-    null as updatedate,
-    null as inserted_date,
-    null as inserted_by,
-    null as updated_date,
-    null as updated_by,
-    null as source_file_date
-from hanyo_work_temp_2
-),
-hanyo_work_temp_3 as (
-select distinct 'DMSYOKUBUN' as kbnmei,
-      dm.dmprnno as attr1,
-      substring(dm.comment1, 1, 40) as attr2,
-      case 
-            when dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-                  then '0003'
-            when dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-                  then '0001'
-            end as attr3,
-      case 
-            when dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-                  then regexp_substr(dm.comment1, 'clﾌﾟﾚﾐｱﾑ.*号')
-            when dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-                  then regexp_substr(dm.comment1, 'ｼｰﾗﾊﾞｰ.*号')
-            end as attr4,
-      null as attr5
-from cir07dmprn dm
-where dm.comment1 like '%clﾌﾟﾚﾐｱﾑ%'
-      or dm.comment1 like '%ｼｰﾗﾊﾞｰ%'
-),
-cte_3 as (
-select hanyo_attr.*  
-from insert_2 hanyo_attr where not exists (
-    select 1
-    from hanyo_work_temp_3
-    where hanyo_attr.kbnmei = hanyo_work_temp_3.kbnmei
-          and hanyo_attr.attr1 = hanyo_work_temp_3.attr1
-)
-),
-insert_3 as (
-select * from cte_3
-union all
-select kbnmei,
-      attr1,
-      attr2,
-      attr3,
-      attr4,
-      attr5,
-      sysdate() as insertdate,
-    null as updatedate,
-    null as inserted_date,
-    null as inserted_by,
-    null as updated_date,
-    null as updated_by,
-    null as source_file_date
-from hanyo_work_temp_3
+with source as (
+    select * from  {{ ref('jpndclitg_integration__hanyo_attr_temp') }}
 ),
 final as (
-select 
-    KBNMEI::VARCHAR(45)  as KBNMEI,
-	ATTR1::VARCHAR(60) as ATTR1,
-	ATTR2::VARCHAR(160) as ATTR2,
-	ATTR3::VARCHAR(60) as ATTR3,
-	ATTR4::VARCHAR(60) as ATTR4,
-	ATTR5::VARCHAR(60) as ATTR5,
-	INSERTDATE::TIMESTAMP_NTZ(9) as INSERTDATE,
-	UPDATEDATE::TIMESTAMP_NTZ(9)  as UPDATEDATE,
-	INSERTED_DATE::TIMESTAMP_NTZ(9) as INSERTED_DATE,
-	'ETL_Batch'::VARCHAR(100) as inserted_by,
-	UPDATED_DATE::TIMESTAMP_NTZ(9) as UPDATED_DATE,
-	UPDATED_BY::VARCHAR(100) as UPDATED_BY,
-	SOURCE_FILE_DATE::VARCHAR(10) as SOURCE_FILE_DATE
-from insert_3
+    select 
+        KBNMEI::VARCHAR(45)  as KBNMEI,
+        ATTR1::VARCHAR(60) as ATTR1,
+        ATTR2::VARCHAR(160) as ATTR2,
+        ATTR3::VARCHAR(60) as ATTR3,
+        ATTR4::VARCHAR(60) as ATTR4,
+        ATTR5::VARCHAR(60) as ATTR5,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ(9) as INSERTDATE,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ(9)  as UPDATEDATE,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ(9) as INSERTED_DATE,
+        'ETL_Batch'::VARCHAR(100) as inserted_by,
+        CURRENT_TIMESTAMP()::TIMESTAMP_NTZ(9) as UPDATED_DATE,
+        NULL::VARCHAR(100) as UPDATED_BY,
+        NULL::VARCHAR(10) as SOURCE_FILE_DATE
+    from source
 )
 select * from final

--- a/models/japan_dcl/jpndclitg_integration/itg/_jpndclitg_integration__itg.yml
+++ b/models/japan_dcl/jpndclitg_integration/itg/_jpndclitg_integration__itg.yml
@@ -419,3 +419,8 @@ models:
     config:
       alias: acgel_predictionresult
       tags: ["dcl_ml_prediction_load","transformation"]
+  
+  - name: jpndclitg_integration__hanyo_attr_temp
+    config:
+      alias: hanyo_attr_temp
+      tags: ["m_dcl_edw_job2","transformation"] 

--- a/models/japan_dcl/jpndclitg_integration/itg/jpndclitg_integration__hanyo_attr_temp.sql
+++ b/models/japan_dcl/jpndclitg_integration/itg/jpndclitg_integration__hanyo_attr_temp.sql
@@ -1,0 +1,77 @@
+with cir07dmprn as (
+    select * from  {{ ref('jpndcledw_integration__cir07dmprn') }}
+),
+tm06dmout as (
+    select * from  {{ ref('jpndcledw_integration__tm06dmout') }}
+),
+
+ct1 AS
+(
+    SELECT 'DMDAIKUBUN' AS KBNMEI,
+        DM.DMPRNNO AS ATTR1,
+        SUBSTRING(DM.COMMENT1, 1, 40) AS ATTR2,
+        '01' AS ATTR3,
+        '会報誌' AS ATTR4,
+        NULL AS ATTR5
+    FROM CIR07DMPRN DM
+    WHERE DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+      OR DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+),
+
+
+ct2 as
+(
+    SELECT 'DMCHUKUBUN' AS KBNMEI,
+        DM.DMPRNNO AS ATTR1,
+        SUBSTRING(DM.COMMENT1, 1, 40) AS ATTR2,
+        TM06_NEXT.DMCHUBUNCODE AS ATTR3,
+        CASE 
+                WHEN DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+                    THEN REPLACE(REGEXP_SUBSTR(DM.COMMENT1, 'CLﾌﾟﾚﾐｱﾑ.*号'), 'CLﾌﾟﾚﾐｱﾑ', '')
+                WHEN DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+                    THEN REPLACE(REGEXP_SUBSTR(DM.COMMENT1, 'ｼｰﾗﾊﾞｰ.*号'), 'ｼｰﾗﾊﾞｰ', '')
+                END AS ATTR4,
+        NULL AS ATTR5
+    FROM CIR07DMPRN DM
+    INNER JOIN (
+        SELECT CAST(MAX(LPAD(DMCHUBUNCODE, 3, '0')) + 1 AS VARCHAR) AS DMCHUBUNCODE
+        FROM TM06DMOUT TM06DMOUT
+        WHERE DMDAIBUNNAME = '会報誌'
+        ) TM06_NEXT ON 1 = 1
+    WHERE DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+        OR DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+),
+
+ct3 AS
+(
+    SELECT DISTINCT 'DMSYOKUBUN' AS KBNMEI,
+        DM.DMPRNNO AS ATTR1,
+        SUBSTRING(DM.COMMENT1, 1, 40) AS ATTR2,
+        CASE 
+                WHEN DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+                    THEN '0003'
+                WHEN DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+                    THEN '0001'
+                END AS ATTR3,
+        CASE 
+                WHEN DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+                    THEN REGEXP_SUBSTR(DM.COMMENT1, 'CLﾌﾟﾚﾐｱﾑ.*号')
+                WHEN DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+                    THEN REGEXP_SUBSTR(DM.COMMENT1, 'ｼｰﾗﾊﾞｰ.*号')
+                END AS ATTR4,
+        NULL AS ATTR5
+    FROM CIR07DMPRN DM
+    WHERE DM.COMMENT1 LIKE '%CLﾌﾟﾚﾐｱﾑ%'
+        OR DM.COMMENT1 LIKE '%ｼｰﾗﾊﾞｰ%'
+),
+
+final as
+(
+    select * from ct1
+    union all
+    select * from ct2
+    union all
+    select * from ct3
+)
+
+select * from final


### PR DESCRIPTION
Fixed jpndcledw_integration__hanyo_attr model

Deactivated the following tables as they are final tables and not being used:

- jpndcledw_integration__cit85osalh_hen_mv_tbl
- jpndcledw_integration__cit85osalh_uri_mv_tbl
- jpndcledw_integration__cit86osalm_uri_mv_tbl
- jpndcledw_integration__wqwt74tbl_new