### PR TITLE
Feature dev pop6 projectexclude to main

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,11 +40,16 @@ tests:
   DNA_CORE_ASP:
     philippines:
       +severity: warn
+      phlitg_integration:
+        sfmc:
+          +severity: error
     thailand:
       +severity: warn
       thaitg_integration:
         pop6: 
-        +severity: error
+          +severity: error
+        sfmc:
+          +severity: error
     malaysia:
       +severity: warn
     vietnam:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -42,6 +42,9 @@ tests:
       +severity: warn
     thailand:
       +severity: warn
+      thaitg_integration:
+        pop6: 
+        +severity: error
     malaysia:
       +severity: warn
     vietnam:
@@ -50,6 +53,9 @@ tests:
       +severity: warn
     singapore:
       +severity: warn
+      sgpitg_integration:
+        pop6: 
+        +severity: error
 
 models:
   dbt_artifacts:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -60,7 +60,7 @@ tests:
       +severity: warn
       sgpitg_integration:
         pop6: 
-        +severity: error
+          +severity: error
 
 models:
   dbt_artifacts:


### PR DESCRIPTION
Modified dbt project.yml file to exclude pop6 and sfmc folders to have severity config as error instead of warn