### PR TITLE
Fixed reference in tt02salem_hen_sub_mv_mt

### DIFF
--- a/models/japan_dcl/jpndcledw_integration/view/jpndcledw_integration__tt02salem_hen_sub_mv_mt.sql
+++ b/models/japan_dcl/jpndcledw_integration/view/jpndcledw_integration__tt02salem_hen_sub_mv_mt.sql
@@ -1,7 +1,7 @@
 WITH tt02salem_hen_sub_mv_mt_tbl
 AS (
   SELECT *
-  FROM {{ source('jpdcledw_integration', 'tt02salem_hen_sub_mv_mt_tbl') }}
+  FROM {{ ref('jpndcledw_integration__tt02salem_hen_sub_mv_mt_tbl') }}
   ),
 final
 AS (


### PR DESCRIPTION
Fixed reference in tt02salem_hen_sub_mv_mt as the underlying model was taken as source instead of reference